### PR TITLE
Initialize `intermediate_states` with `n_dims`

### DIFF
--- a/source_code/pacmap/pacmap.py
+++ b/source_code/pacmap/pacmap.py
@@ -356,7 +356,7 @@ def pacmap(
 
     if intermediate:
         itr_dic = [0, 10, 30, 60, 100, 120, 140, 170, 200, 250, 300, 350, 450]
-        intermediate_states = np.empty((13, n, 2), dtype=np.float32)
+        intermediate_states = np.empty((13, n, n_dims), dtype=np.float32)
     else:
         intermediate_states = None
 


### PR DESCRIPTION
`intermediate_states` now correctly has the requested dimensions. It was previously hardcoded to `2`, which caused an exception if `intermediate=True` and `n_dims` was anything other than `2`.