### PR TITLE
WIP fix path to source code folder in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 
 [options]
 package_dir =
-    = src
+    = source_code
 packages = find:
 python_requires = >=3.6
 install_requires =
@@ -29,4 +29,4 @@ install_requires =
     numpy >= 1.20
 
 [options.packages.find]
-where = src
+where = source_code


### PR DESCRIPTION
This PR addresses the installation issue mentioned in #25. The below now works correctly on Google Collab, for example:

```
!pip install git+https://github.com/nfultz/PaCMAP

from pacmap import pacmap
```

Note that the pacmap module (`pacmap.py`) is within a package also named pacmap (the folder `source_code/pacmap/`), and the package init (the module `source_code/pacmap/__init__.py`) doesn't do anything. 

That is why I had to do `from pacmap import pacmap` which looks weird. 




