### PR TITLE
remove setuptools as dependency

### DIFF
--- a/source/pacmap/__init__.py
+++ b/source/pacmap/__init__.py
@@ -7,4 +7,4 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__all__ = ["pacmap"]
+__all__ = ["PaCMAP", "sample_neighbors_pair"]

--- a/source/pacmap/__init__.py
+++ b/source/pacmap/__init__.py
@@ -1,5 +1,10 @@
 from .pacmap import PaCMAP, sample_neighbors_pair
 
-import pkg_resources
-__version__ = pkg_resources.get_distribution('pacmap').version
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version('pacmap')
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 __all__ = ["pacmap"]


### PR DESCRIPTION
right now, if you install `pacmap` into a completely fresh venv, it will fail to execute `import pacmap` due to the `import pkg_resources`. Starting with Python 3.8, the builtin `importlib` supplies the requisite functionality