### PR TITLE
prototype support for `n_components=1`

### DIFF
--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -869,9 +869,11 @@ class PaCMAP(BaseEstimator):
             self.random_state = 0
             _RANDOM_STATE = None  # Reset random state
 
-        if self.n_components < 2:
+        if self.n_components < 1:
             raise ValueError(
                 "The number of projection dimensions must be at least 2.")
+        if self.n_components == 1:
+            logger.warning('Warning: Defaults were chosen around dimension 2. Dimension 1 has not been tested.')
         if self.lr <= 0:
             raise ValueError("The learning rate must be larger than 0.")
         if self.distance == "hamming" and apply_pca:

--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -871,9 +871,10 @@ class PaCMAP(BaseEstimator):
 
         if self.n_components < 1:
             raise ValueError(
-                "The number of projection dimensions must be at least 2.")
-        if self.n_components == 1:
-            logger.warning('Warning: Defaults were chosen around dimension 2. Dimension 1 has not been tested.')
+                "The number of projection dimensions must be at least 1."
+            )
+        if self.n_components != 2:
+            logger.debug("Note: `n_components != 2` have not been thoroughly tested.")
         if self.lr <= 0:
             raise ValueError("The learning rate must be larger than 0.")
         if self.distance == "hamming" and apply_pca:

--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -874,7 +874,7 @@ class PaCMAP(BaseEstimator):
                 "The number of projection dimensions must be at least 1."
             )
         if self.n_components != 2:
-            logger.debug("Note: `n_components != 2` have not been thoroughly tested.")
+            logger.warning("Note: `n_components != 2` have not been thoroughly tested.")
         if self.lr <= 0:
             raise ValueError("The learning rate must be larger than 0.")
         if self.distance == "hamming" and apply_pca:


### PR DESCRIPTION
see #82 


```bash
$ uv run --with 'ipython, git+https://github.com/mathematicalmichael/PaCMAP@feature/unit-dimension' ipython
 Updated https://github.com/mathematicalmichael/PaCMAP (42a630b)
Installed 26 packages in 243ms
```
```ipython
Python 3.11.9 (main, Aug 14 2024, 04:17:21) [Clang 18.1.8 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pacmap import PaCMAP

In [2]: PaCMAP(n_components=1)
Warning: Defaults were chosen around dimension 2. Dimension 1 has not been tested.
Out[2]: PaCMAP(n_components=1, random_state=0)
```