### PR TITLE
more flexible loading method

### DIFF
--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -755,8 +755,8 @@ def load(
     If the index and reducer are saved with `common_prefix`,
     this will load both into the returned object.
 
-    Otherwise, pass `index_path` to attach any saved index.
-    `reducer_path` can be used to specify the full path to load.
+    Otherwise, pass `index_path` to attach any saved index and
+    `reducer_path` to load the saved associated reducer object.
 
     Note: only one of `common_prefix` or `reducer_path` is needed.
     '''


### PR DESCRIPTION
Problem addressed: the reducer and index paths may diverge when using experiment tracking software that automatically assigns names to uploaded artifacts.
The `load` method should be flexible enough to take in as arguments the two paths required to load the reducer.

This change maintains backwards-compatibility with `common_prefix` as the only argument.