### PR TITLE
Minor fixes

### DIFF
--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -11,6 +11,7 @@ import pickle as pkl
 
 from sklearn.base import BaseEstimator
 from sklearn.decomposition import TruncatedSVD, PCA
+from sklearn.utils.validation import check_is_fitted
 from sklearn import preprocessing
 from annoy import AnnoyIndex
 
@@ -1032,6 +1033,9 @@ class PaCMAP(BaseEstimator):
         save_pairs: bool, optional
             Whether to save the pairs that are sampled from the dataset. Useful for reproducing results.
         '''
+
+        # If the estimator is not fitted, then raise NotFittedError
+        check_is_fitted(estimator=self, attributes="embedding_")
 
         # Preprocess the data
         X = np.copy(X).astype(np.float32)

--- a/source/pacmap/pacmap.py
+++ b/source/pacmap/pacmap.py
@@ -360,7 +360,7 @@ def preprocess_X(X, distance, apply_pca, verbose, seed, high_dim, low_dim):
         xmin = 0  # placeholder
         xmax = 0  # placeholder
         xmean = np.mean(X, axis=0)
-        X -= np.mean(X, axis=0)
+        X -= xmean
         tsvd = TruncatedSVD(n_components=100, random_state=seed)
         X = tsvd.fit_transform(X)
         pca_solution = True


### PR DESCRIPTION
Hello,

I made 2 minor contributions: 

1. In the preprocess_X function, to use `xmean` var that was already calculated when doing the mean centering, saving an extra mean calculation step.
2. Make use of the `check_is_fitted` function from sklearn in PaCMAP's transform method to ensure it conforms more with scikit-learn's API.

Thanks,
Huy